### PR TITLE
Add plugins SDK support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+yarn.lock

--- a/config-ant.json
+++ b/config-ant.json
@@ -1,0 +1,7 @@
+{
+	"globClass": "docroot/WEB-INF/classes/**/*.class",
+	"globJava": "docroot/WEB-INF/src/**/*.java",
+	"globJs": "docroot/**/*.js",
+	"globJsp": "docroot/**/*.jsp",
+	"globSass": "docroot/**/*.scss"
+}

--- a/tasks/java.js
+++ b/tasks/java.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const ant = require('./lib/ant');
 const configs = require('./lib/configs');
 const duration = require('gulp-duration');
+const fs = require('fs');
 const gradle = require('./lib/gradle');
 const gulp = require('gulp');
 const gutil = require('gulp-util');
@@ -28,14 +30,16 @@ gulp.task('build-java', (done) => {
 	projectDeps().then((projects) => {
 		gutil.log(gutil.colors.magenta('java'), 'Compiling Java');
 
-		gradle(buildGradleArgs(projects)).then(
-			(gradleOutput) => {
+		let compileResult = fs.existsSync('build.gradle') ? gradle(buildGradleArgs(projects)) : ant(['compile']);
+
+		compileResult.then(
+			(compileOutput) => {
 				gulp.src(configs.globClass)
 					.pipe(javaTimer)
 					.pipe(gulp.dest(configs.pathExploded))
 					.on('end', () => done());
 			},
-			() => {
+			(compileError) => {
 				gutil.log(gutil.colors.magenta('java'), gutil.colors.red('Errors compiling Java. Check compiler output.'));
 				done();
 			}

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -4,6 +4,7 @@ const buildAmd = require('metal-tools-build-amd/lib/pipelines/buildAmd');
 const cache = require('gulp-cached');
 const configs = require('./lib/configs');
 const duration = require('gulp-duration');
+const fs = require('fs');
 const gulp = require('gulp');
 const gutil = require('gulp-util');
 const path = require('path');
@@ -30,8 +31,10 @@ gulp.task('build-javascript-es6', (done) => {
 });
 
 gulp.task('build-javascript', (done) => {
+	let globDestination = (configs.globJs.indexOf('META-INF/resources') != -1) ? path.join(configs.pathExploded, 'META-INF/resources') : configs.pathExploded;
+
 	gutil.log(gutil.colors.magenta('javascript-es5'), 'Copying ES5 files.');
 	return gulp.src([configs.globJs, '!' + configs.globEs6])
-	.pipe(gulp.dest(path.join(configs.pathExploded, 'META-INF/resources')))
+	.pipe(gulp.dest(globDestination))
 	.pipe(duration('javascript-es5'));
 });

--- a/tasks/lib/ant.js
+++ b/tasks/lib/ant.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const childProcess = require('child_process');
+
+const getAntChildProcess = args => {
+	const cwd = process.cwd();
+
+	return childProcess.spawn('ant', args, { cwd });
+};
+
+module.exports = args => {
+	return new Promise((resolve, reject) => {
+		const cp = getAntChildProcess(args);
+		let antOutput = '';
+		cp.stdout.on('data', data => {
+			antOutput += data.toString();
+		});
+		cp.stderr.pipe(process.stderr);
+		cp.on('exit', code => {
+			if (code === 0) {
+				resolve(antOutput);
+			} else {
+				reject(new Error('Unable to call ant ' + args.join(' ')));
+			}
+		});
+	});
+};

--- a/tasks/lib/bnd.js
+++ b/tasks/lib/bnd.js
@@ -7,47 +7,140 @@ const readline = require('readline');
 class Bnd {
 	static getJarName(dir) {
 		return Bnd.getSymbolicName(dir).then(
-			symbolicName => symbolicName + '.jar'
+			symbolicName => (symbolicName + (fs.existsSync('build.gradle') ? '.jar' : '.war'))
 		);
 	}
 
 	static getBundleVersion(dir) {
-		return Bnd.getProperty(dir, 'Bundle-Version');
+		return Bnd.getProperty(
+			dir,
+			'Bundle-Version',
+			(data) => data['version'],
+			(buildPropertiesFile, pluginPackageFile, resolve, reject, defaultValue) => {
+				Bnd.getJavaProperty(
+					buildPropertiesFile,
+					'lp.version',
+					(buildVersion) => {
+						Bnd.getJavaProperty(
+							pluginPackageFile,
+							'module-incremental-version',
+							(incrementVersion) => resolve(buildVersion + '.' + incrementVersion),
+							(err) => resolve(defaultValue),
+							defaultValue
+						);
+					},
+					(err) => resolve(defaultValue),
+					defaultValue
+				);
+			},
+			'0'
+		);
 	}
 
 	static getSymbolicName(dir) {
-		return Bnd.getProperty(dir, 'Bundle-SymbolicName');
+		return Bnd.getProperty(
+			dir,
+			'Bundle-SymbolicName',
+			(data) => data['liferayTheme']['distName'],
+			(buildPropertiesFile, pluginPackageFile, resolve, reject, defaultValue) => {
+				resolve(path.basename(process.cwd()));
+			},
+			path.basename(process.cwd())
+		);
 	}
 
-	static getProperty(dir, property) {
+	static getProperty(dir, property, getPackageJSONValue, getPluginPackageValue, defaultValue) {
 		return new Promise((resolve, reject) => {
-			const bnd = path.join(dir, 'bnd.bnd');
-			try {
-				const reader = readline.createInterface({
-					input: fs.createReadStream(bnd)
-				});
+			const bndFile = path.join(dir, 'bnd.bnd');
+			const buildPropertiesFile = path.join(dir, '../../build.properties');
+			const packageFile = path.join(dir, 'package.json');
+			const pluginPackageFile = path.join(dir, 'docroot/WEB-INF/liferay-plugin-package.properties');
+			const themeFile = path.join(dir, 'liferay-theme.json');
 
-				let foundName = false;
-
-				reader.on('line', function(line) {
-					if (line.indexOf(property) === 0) {
-						const parts = line.split(':');
-
-						foundName = true;
-
-						resolve(parts[1].trim());
-					}
-				});
-
-				reader.on('close', function() {
-					if (!foundName) {
-						resolve(path.basename(process.cwd()));
-					}
-				});
-			} catch (e) {
-				reject(Error('Could not open bnd file.'));
+			if (fs.existsSync(bndFile)) {
+				Bnd.getBndProperty(bndFile, property, resolve, reject, defaultValue);
+			}
+			else if (fs.existsSync(themeFile) && fs.existsSync(packageFile)) {
+				Bnd.getPackageJSONProperty(packageFile, getPackageJSONValue, resolve, reject, defaultValue);
+			}
+			else if (fs.existsSync(buildPropertiesFile) && fs.existsSync(pluginPackageFile)) {
+				getPluginPackageValue(buildPropertiesFile, pluginPackageFile, resolve, reject, defaultValue)
+			}
+			else {
+				resolve(defaultValue);
 			}
 		});
+	}
+
+	static getBndProperty(bndFile, property, resolve, reject, defaultValue) {
+		try {
+			const reader = readline.createInterface({
+				input: fs.createReadStream(bndFile)
+			});
+
+			let foundName = false;
+
+			reader.on('line', function(line) {
+				if (line.indexOf(property) === 0) {
+					const parts = line.split(':');
+
+					foundName = true;
+
+					resolve(parts[1].trim());
+				}
+			});
+
+			reader.on('close', function() {
+				if (!foundName) {
+					resolve(defaultValue);
+				}
+			});
+		}
+		catch (e) {
+			reject(Error('Could not open ' + bndFile));
+		}
+	}
+
+	static getJavaProperty(propertyFile, property, resolve, reject, defaultValue) {
+		try {
+			const reader = readline.createInterface({
+				input: fs.createReadStream(propertyFile)
+			});
+
+			let foundName = false;
+
+			reader.on('line', function(line) {
+				line = line.trim();
+
+				if (line.indexOf(property) === 0) {
+					const parts = line.split('=');
+
+					foundName = true;
+
+					resolve(parts[1].trim());
+				}
+			});
+
+			reader.on('close', function() {
+				if (!foundName) {
+					resolve(defaultValue);
+				}
+			});
+		}
+		catch (e) {
+			reject(Error('Could not open ' + propertyFile));
+		}
+	}
+
+	static getPackageJSONProperty(packageFile, getPackageJSONValue, resolve, reject, defaultValue) {
+		try {
+			fs.readFile(packageFile, (err, jsonText) => {
+				resolve(getPackageJSONValue(JSON.parse(jsonText)));
+			})
+		}
+		catch (e) {
+			resolve(defaultValue);
+		}
 	}
 }
 

--- a/tasks/lib/configs.js
+++ b/tasks/lib/configs.js
@@ -5,6 +5,13 @@ const gutil = require('gulp-util');
 const path = require('path');
 
 let configs = require('../../config.json');
+
+
+
+if (fs.existsSync(path.join(process.cwd(), 'build.xml'))) {
+	configs = Object.assign(configs, require('../../config-ant.json'));
+}
+
 const userConfigsPath = path.resolve(require('os').homedir(), '.lwatch.json');
 if (fs.existsSync(userConfigsPath)) {
 	configs = Object.assign(configs, require(userConfigsPath));

--- a/tasks/lib/gogo.js
+++ b/tasks/lib/gogo.js
@@ -17,7 +17,7 @@ module.exports = {
 					.map(line => line.trim())
 					.filter(line => !isNaN(parseFloat(line)) && isFinite(line));
 				if (info.length === 0) {
-					throw new Error('Could not find installed bundle.');
+					throw new Error('Could not find installed bundle ' + symbolicName);
 				}
 				return info[0];
 			});

--- a/tasks/lib/projectDeps.js
+++ b/tasks/lib/projectDeps.js
@@ -1,12 +1,13 @@
 'use strict';
 
+const fs = require('fs');
 const gradle = require('./gradle');
 
 module.exports = () => {
 	return new Promise((resolve, reject) => {
 		if (global.projectDeps) {
 			resolve(global.projectDeps);
-		} else {
+		} else if (fs.exists('build.gradle')) {
 			gradle(['dependencies', '--configuration', 'compile']).then(
 				gradleOutput => {
 					let projectDeps = gradleOutput
@@ -28,6 +29,8 @@ module.exports = () => {
 					);
 				}
 			);
+		} else {
+			resolve([]);
 		}
 	});
 };

--- a/tasks/lib/soyDeps.js
+++ b/tasks/lib/soyDeps.js
@@ -2,6 +2,7 @@
 
 const bnd = require('./bnd');
 const configs = require('./configs');
+const fs = require('fs');
 const gradle = require('./gradle');
 const path = require('path');
 
@@ -33,7 +34,7 @@ module.exports = () => {
 	return new Promise((resolve, reject) => {
 		if (global.soyDeps) {
 			resolve(global.soyDeps);
-		} else {
+		} else if (fs.existsSync('build.gradle')) {
 			gradle(['dependencies', '--configuration', 'soyCompile']).then(
 				gradleOutput => {
 					let soyDeps = Object.keys(configs.soyCompile || []).map(
@@ -64,6 +65,8 @@ module.exports = () => {
 					);
 				}
 			);
+		} else {
+			resolve([]);
 		}
 	});
 };

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -36,11 +36,13 @@ gulp.task('unzip-portal-common-css', [], (done) => {
 });
 
 gulp.task('build-sass', ['unzip-portal-common-css'], (done) => {
+	let globDestination = (configs.globJs.indexOf('META-INF/resources') != -1) ? path.join(configs.pathExploded, 'META-INF/resources') : configs.pathExploded;
+
 	gutil.log(gutil.colors.magenta('sass'), 'Processing files');
 	return gulp.src(configs.globSass)
 	.pipe(sass({
 		includePaths: ['build/portal-common-css']
 	}))
 	.pipe(duration('sass'))
-	.pipe(gulp.dest(path.join(configs.pathExploded, 'META-INF/resources')));
+	.pipe(gulp.dest(globDestination));
 });

--- a/tasks/unjar.js
+++ b/tasks/unjar.js
@@ -39,7 +39,7 @@ gulp.task('unjar', (done) => {
 		}
 
 		if (!fs.existsSync(jarPath)) {
-			reject(new Error('Unable to find installed bundle.'));
+			reject(new Error('Unable to find installed bundle ' + info.symbolicName));
 		}
 		else {
 			gulp.src(jarPath)


### PR DESCRIPTION
As people are upgrading portlets from 6.2, something that might help ease their upgrade experience is if we made lwatch work against WABs. This adds in the initial support for really simple changes (js, css, java). It achieves this by locating the WAB from inside of osgi/state and then unzipping it locally. Note that because it's osgi/state, as soon as we refresh the bundle, the bundleFile disappears. Thus, the code also allows for falling back to the already exploded folder.

While there's still other things that aren't possible yet, such as copying .jar files from lib in case you update ivy.xml, this might make it a lot easier for people working with WABs upgraded from older versions of Liferay.